### PR TITLE
Misspelled enabled

### DIFF
--- a/config/git-notifier-config.yml.sample
+++ b/config/git-notifier-config.yml.sample
@@ -100,6 +100,6 @@ skip_commits_older_than: 7
 
 # This is developer debugging options. Do not uncomment it if You aren't Jedi
 # debug:
-#   enable: true
+#   enabled: true
 #   log_directory: /path/to/log/directory
 


### PR DESCRIPTION
Hello,

Misspelled 'enable' in config/git-notifier-config.yml.sample
Regarding lib/logger.rb must be "enabled"

regards.
