### PR TITLE
Add config option for include branches with tests

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,3 +1,5 @@
+__This fork is for adding the ability to restrict the emails from unwanted branches
+
 h1. Git Commit Notifier
 
 __by Bodo Tasche (bodo 'at' wannawork 'dot' de), Akzhan Abdulin (akzhan 'dot' abdulin 'at' gmail 'dot' com), Csoma Zoltan (Primalgrasp) (zoltan 'at' primalgrasp 'dot' com)__

--- a/config/git-notifier-config.yml.sample
+++ b/config/git-notifier-config.yml.sample
@@ -7,6 +7,10 @@ ignore_merge: false
 # Limit lines per diff
 # lines_per_diff: 300
 
+# defines what branches to email for (defaults to all)
+# include_branches: master
+# include_branches: [master,some_other_branch]
+
 # The recipient (or newsgroup for nntp) for the commit
 # It can send to multiple destination, just seperate email address by "," :
 mailinglist: developers@example.com,dev2@example.com,dev3@example.com,cto@example.com

--- a/lib/commit_hook.rb
+++ b/lib/commit_hook.rb
@@ -44,21 +44,30 @@ class CommitHook
         )
         return
       end
-
+      include_branches = config["include_branches"]
+      
       logger.debug('----')
       logger.debug("pwd: #{Dir.pwd}")
       logger.debug("ref_name: #{ref_name}")
       logger.debug("rev1: #{rev1}")
       logger.debug("rev2: #{rev2}")
+      logger.debug("included branches: #{include_branches.join(',')}") unless include_branches.nil?
 
 
-      info("Sending mail...")
-
-    prefix = @config["emailprefix"] || Git.repo_name
-    branch_name = (ref_name =~ /master$/i) ? "" : "/#{ref_name.split("/").last}"
+      prefix = @config["emailprefix"] || Git.repo_name
+      branch_name = ref_name.split("/").last
 
       logger.debug("prefix: #{prefix}")
       logger.debug("branch: #{branch_name}")
+
+      unless include_branches.nil? || include_branches.include?(branch_name)
+        info("Supressing mail for branch #{branch_name}...")
+        return
+      end
+      
+      branch_name = branch_name.eql?('master') ? "" : "/#{branch_name}"
+      
+      info("Sending mail...")
 
       diff2html = DiffToHtml.new(Dir.pwd, config)
       diff2html.diff_between_revisions(rev1, rev2, prefix, ref_name)

--- a/spec/fixtures/git-notifier-with-branch-restrictions.yml
+++ b/spec/fixtures/git-notifier-with-branch-restrictions.yml
@@ -1,0 +1,22 @@
+delivery_method: sendmail # smtp or sendmail
+ignore_merge: true # set to true if you want to ignore empty merge messages
+
+# defines what branches to email for
+include_branches: [master, branch2]
+
+
+smtp_server:
+  address: localhost
+  port: 25
+  domain: localhost
+  user_name: user@localhost
+  password: password
+  authentication: plain
+  enable_tls: false
+
+sendmail_options:
+  location: /usr/sbin/sendmail
+  arguments:
+
+  
+

--- a/spec/lib/commit_hook_spec.rb
+++ b/spec/lib/commit_hook_spec.rb
@@ -18,17 +18,46 @@ describe CommitHook do
     run_with_config('spec/fixtures/git-notifier-group-email-by-push.yml', 1)
   end
 
-  def run_with_config(config, times)
+  it "should ignore commits to non specified branches if branch limits supplied" do
+    # 4 commits, one email for each of them, without merge
+    run_and_reject('spec/fixtures/git-notifier-with-branch-restrictions.yml',0,'refs/heads/branchx')
+  end
+
+  it "should email for commits to branch in include_branch" do
+    # 4 commits, one email for each of them, without merge
+    run_with_config('spec/fixtures/git-notifier-with-branch-restrictions.yml',4,'refs/heads/branch2')
+  end
+  
+
+  it "should email for commits to master if master set as include_branch" do
+    # 4 commits, one email for each of them, without merge
+    run_with_config('spec/fixtures/git-notifier-with-branch-restrictions.yml',4)
+  end
+  
+  
+  def run_with_config(config, times, branch = 'refs/heads/master')
     expect_repository_access
 
     emailer = mock!.send.times(times).subject
     mock(Emailer).new(anything, anything) { emailer }.times(times)
-
     mock(CommitHook).info(/Sending mail/)
 
     any_instance_of(DiffToHtml, :check_handled_commits => lambda { |commits| commits })
-    CommitHook.run config, REVISIONS.first, REVISIONS.last, 'refs/heads/master'
+    CommitHook.run config, REVISIONS.first, REVISIONS.last, branch
   end
+  
+
+  def run_and_reject(config,times,branch)
+    mock(Git).mailing_list_address { 'recipient@test.com' }
+
+    emailer = mock!.send.times(times).subject
+    mock(Emailer).new(anything, anything).times(times)
+
+    mock(CommitHook).info(/Supressing mail for branch/)
+
+    CommitHook.run config, REVISIONS.first, REVISIONS.last, branch
+  end
+  
 
   def test_commit_from
     # 1 commit with a from: adress


### PR DESCRIPTION
This change is to restrict emails for branches.  We use a hacked in version of this at work, and I thought I would share in case someone else thought it would come in handy

The only part i didn't add tests for was to make sure the branch name shows up correctly in emails for branch commits.  I'm not all that familiar with rspec / mocking and did not know how to specify that.  I changed the extraction of branch name from the refs parameter and figured a test to verify the proper insertion of the leading slash would be nice.
