### PR TITLE
Add ignore_ws option (default: true) to ignore whitespace in diffs

### DIFF
--- a/config/git-notifier-config.yml.sample
+++ b/config/git-notifier-config.yml.sample
@@ -110,6 +110,9 @@ unique_commits_per_branch: false
 
 show_master_branch_name: false
 
+# ignore whitespace?
+ignore_whitespace = true
+
 # This is developer debugging options. Do not uncomment it if You aren't Jedi
 # debug:
 #   enabled: true

--- a/lib/git_commit_notifier/diff_to_html.rb
+++ b/lib/git_commit_notifier/diff_to_html.rb
@@ -67,6 +67,11 @@ module GitCommitNotifier
       config['lines_per_diff']
     end
 
+    def ignore_whitespace
+      return true if @config['ignore_whitespace'] != false
+      return false
+    end
+
     def skip_lines?
       lines_per_diff && (@lines_added >= lines_per_diff)
     end
@@ -414,7 +419,7 @@ module GitCommitNotifier
 
     def diff_for_commit(commit)
       @current_commit = commit
-      raw_diff = Git.show(commit)
+      raw_diff = Git.show(commit, ignore_whitespace)
       raise "git show output is empty" if raw_diff.empty?
 
       commit_info = extract_commit_info_from_git_show_output(raw_diff)

--- a/lib/git_commit_notifier/git.rb
+++ b/lib/git_commit_notifier/git.rb
@@ -4,8 +4,10 @@ class GitCommitNotifier::Git
       `#{cmd}`
     end
 
-    def show(rev)
-      from_shell("git show #{rev.strip} -w")
+    def show(rev, ignore_whitespace=true)
+      gitopt = ""
+      gitopt = "-w" if ignore_whitespace
+      from_shell("git show #{rev.strip} #{gitopt}")
     end
 
     def log(rev1, rev2)


### PR DESCRIPTION
Ignoring whitespace in git show was previously hard-coded, but for
some code repositories, developers may want to see whitespace differences.
Setting ignore_ws = false in the config.yml will show whitespace diffs.
