### PR TITLE
Add a "debug" delivery mechanism

### DIFF
--- a/config/git-notifier-config.yml.sample
+++ b/config/git-notifier-config.yml.sample
@@ -28,7 +28,7 @@ mailinglist: developers@example.com,dev2@example.com,dev3@example.com,cto@exampl
 # stylesheet file (embedded template/styles.css by default)
 # stylesheet: /absolute/path/to/readable/stylesheet.css
 
-# select the delivery method: smtp, nntp, or sendmail 
+# select the delivery method: smtp, nntp, sendmail, or debug
 delivery_method: sendmail 
 
 # Optionally group email by push: don't send an email for each commit when true.

--- a/lib/git_commit_notifier/emailer.rb
+++ b/lib/git_commit_notifier/emailer.rb
@@ -52,6 +52,12 @@ class GitCommitNotifier::Emailer
     IO.read(stylesheet)
   end
 
+  def perform_delivery_debug(content)
+    content.each do |line|
+      puts line
+    end
+  end
+
   def perform_delivery_smtp(content, smtp_settings)
     settings = { }
     %w(address port domain user_name password authentication enable_tls).each do |key|
@@ -128,6 +134,7 @@ class GitCommitNotifier::Emailer
     case config['delivery_method'].to_sym
     when :smtp then perform_delivery_smtp(content, config['smtp_server'])
     when :nntp then perform_delivery_nntp(content, config['nntp_settings'])
+    when :debug then perform_delivery_debug(content)
     else # sendmail
       perform_delivery_sendmail(content, @config['sendmail_options'])
     end


### PR DESCRIPTION
Add the debug delivery handler -- print out what we WOULD have sent
to stdout instead of mail.  Useful for debugging without killing
your mail server.
