### PR TITLE
Only include branch in output if present

### DIFF
--- a/lib/git_commit_notifier/diff_to_html.rb
+++ b/lib/git_commit_notifier/diff_to_html.rb
@@ -460,7 +460,7 @@ module GitCommitNotifier
 
       title += "<br />\n"
 
-      title += "<strong>Branch:</strong> #{CGI.escapeHTML(branch_name)}\n<br />"
+      title += "<strong>Branch:</strong> #{CGI.escapeHTML(branch_name)}\n<br />" if branch_name
       title += "<strong>Date:</strong> #{CGI.escapeHTML commit_info[:date]}\n<br />"
       title += "<strong>Author:</strong> #{CGI.escapeHTML(commit_info[:author])} &lt;#{commit_info[:email]}&gt;\n<br />"
       title += "<strong>Committer:</strong> #{CGI.escapeHTML(commit_info[:committer])} &lt;#{commit_info[:commit_email]}&gt;\n</div>"


### PR DESCRIPTION
I had an issue with a local test. I was simply calling `git-commit-notifier config.yml oldrev newrev`, without using a `post-receive` hook and it wouldn't work because `branch_name` was `nil`.
