### PR TITLE
Force UTF-8 encoding on git log/show output.

### DIFF
--- a/lib/git_commit_notifier/git.rb
+++ b/lib/git_commit_notifier/git.rb
@@ -10,11 +10,15 @@ class GitCommitNotifier::Git
       gitopt = ""
       gitopt += " --pretty=fuller"
       gitopt += " -w" if ignore_whitespace
-      from_shell("git show #{rev.strip}#{gitopt}")
+      data = from_shell("git show #{rev.strip}#{gitopt}")
+      data.force_encoding(Encoding::UTF_8) if data.respond_to?(:force_encoding)
+      data
     end
 
     def log(rev1, rev2)
-      from_shell("git log --pretty=fuller #{rev1}..#{rev2}").strip
+      data = from_shell("git log --pretty=fuller #{rev1}..#{rev2}").strip
+      data.force_encoding(Encoding::UTF_8) if data.respond_to?(:force_encoding)
+      data
     end
 
     def changed_files(rev1, rev2)


### PR DESCRIPTION
According to the man pages, encodings for these commands defaults to UTF-8.

By using `force_encoding` I was able to fix issue #103 for me.
