### PR TITLE
Ensure stdin is actually usable, otherwise tell the user.

### DIFF
--- a/lib/git_commit_notifier/executor.rb
+++ b/lib/git_commit_notifier/executor.rb
@@ -10,7 +10,12 @@ module GitCommitNotifier
         GitCommitNotifier::CommitHook.show_error("You have to add a path to the config file for git-commit-notifier")
         puts "Usage:  git-commit-notifier config-script [oldrev newrev [ref]]"
       when 1
-        oldrev, newrev, ref = $stdin.gets.strip.split
+        stdin = $stdin.gets
+        if stdin.nil?
+          GitCommitNotifier::CommitHook.show_error("No data given on standard input")
+          return
+        end
+        oldrev, newrev, ref = stdin.strip.split
         GitCommitNotifier::CommitHook.run args.first, oldrev, newrev, ref
       when 2
         GitCommitNotifier::CommitHook.run args.first, args.last, args.last, ""


### PR DESCRIPTION
Just a tiny check on stdin, otherwise the `strip` method errors out, because `$stdin.gets` returns `nil`.

Can be reproduces by calling `git-commit-notifier config.yml` and then simply pressing `CTRL+d`
