### PR TITLE
Expand tabs before escaping HTML

### DIFF
--- a/lib/git_commit_notifier/escape_helper.rb
+++ b/lib/git_commit_notifier/escape_helper.rb
@@ -12,6 +12,6 @@ module GitCommitNotifier::EscapeHelper
   end
 
   def escape_content(s)
-    expand_tabs(CGI.escapeHTML(s), 4).gsub(" ", "&nbsp;")
+    CGI.escapeHTML(expand_tabs(s, 4)).gsub(" ", "&nbsp;")
   end
 end


### PR DESCRIPTION
This decreases the likelihood that tab expansion will be negatively influenced by
non-printable characters introduced by the html escaping.
