### PR TITLE
Suggestion: More changes for gitweb integration

### DIFF
--- a/lib/git_commit_notifier/diff_to_html.rb
+++ b/lib/git_commit_notifier/diff_to_html.rb
@@ -161,7 +161,7 @@ module GitCommitNotifier
       # TODO: these filenames, etc, should likely be properly html escaped
       if config['link_files']
         file_name = if config["link_files"] == "gitweb" && config["gitweb"]
-          "<a href='#{config['gitweb']['path']}?p=#{config['gitweb']['project'] || Git.repo_name}.git;f=#{file_name};h=#{@current_sha};hb=#{@current_commit}'>#{file_name}</a>"
+          "<a href='#{config['gitweb']['path']}?p=#{config['gitweb']['project'] || "#{Git.repo_name}.git"};f=#{file_name};h=#{@current_sha};hb=#{@current_commit}'>#{file_name}</a>"
         elsif config["link_files"] == "gitorious" && config["gitorious"]
           "<a href='#{config['gitorious']['path']}/#{config['gitorious']['project']}/#{config['gitorious']['repository']}/blobs/#{branch_name}/#{file_name}'>#{file_name}</a>"
         elsif config["link_files"] == "cgit" && config["cgit"]
@@ -448,7 +448,7 @@ module GitCommitNotifier
     def markup_commit_for_html(commit)
       commit = if config["link_files"]
         if config["link_files"] == "gitweb" && config["gitweb"]
-          "<a href='#{config['gitweb']['path']}?p=#{Git.repo_name}.git;a=commitdiff;h=#{commit}'>#{commit}</a>"
+          "<a href='#{config['gitweb']['path']}?p=#{config['gitweb']['project'] || "#{Git.repo_name}.git"};a=commitdiff;h=#{commit}'>#{commit}</a>"
         elsif config["link_files"] == "gitorious" && config["gitorious"]
           "<a href='#{config['gitorious']['path']}/#{config['gitorious']['project']}/#{config['gitorious']['repository']}/commit/#{commit}'>#{commit}</a>"
         elsif config["link_files"] == "trac" && config["trac"]


### PR DESCRIPTION
First of all, the gitweb integration is done in two places. The same
approach should be taken in both places. (Perhaps refactoring is in
order, but it is so tiny)

Second, if one has a bare repository called simply 'project', then
gitweb integration wasn't possible using the old method.

Now, these are the gitweb.project settings for various circumstances:

A "normal", non-bare repository called "test.git":
project: test.git/.git

A bare repository called "test.git":
project: test.git

A bare repository called "test":
project: test

This follows convenction for the 'h' parameter that gitweb uses
