### PR TITLE
Revert previous change setting the email date to the date of the commit.

### DIFF
--- a/lib/git_commit_notifier/emailer.rb
+++ b/lib/git_commit_notifier/emailer.rb
@@ -130,7 +130,10 @@ class GitCommitNotifier::Emailer
     
     content = []
     content << "From: #{from}" if !from.nil?
-    content << "Date: #{@date}" if !@date.nil?
+    
+    # Setting the email date from the commit date is undesired by those
+    # who sort their email by send date instead of receive date
+    #content << "Date: #{@date}" if !@date.nil?
 
     content.concat [
         "#{to_tag}: #{quote_if_necessary(@recipient, 'utf-8')}",


### PR DESCRIPTION
Some don't like this behavior, as they sort their email by send date rather than receive date.

Heh, I even promise I didn't break the specs this time :)
