### PR TITLE
Fix spec to use from_shell, not lines_from_shell

### DIFF
--- a/spec/lib/git_commit_notifier/git_spec.rb
+++ b/spec/lib/git_commit_notifier/git_spec.rb
@@ -104,11 +104,11 @@ describe GitCommitNotifier::Git do
 
   describe :new_empty_branch do
     it "should commit an empty branch and output nothing" do
-      mock(GitCommitNotifier::Git).lines_from_shell("git rev-parse --not --branches") {
+      mock(GitCommitNotifier::Git).from_shell("git rev-parse --not --branches") {
         "^#{SAMPLE_REV}\n^#{SAMPLE_REV}\n^#{SAMPLE_REV_2}" }
       mock(GitCommitNotifier::Git).rev_parse("refs/heads/branch2") { SAMPLE_REV }
-      stub(GitCommitNotifier::Git).lines_from_shell("git rev-list --reverse #{SAMPLE_REV} ^#{SAMPLE_REV_2}") { SAMPLE_REV }
-      mock(GitCommitNotifier::Git).lines_from_shell("git rev-list --reverse ^#{SAMPLE_REV} ^#{SAMPLE_REV_2} #{SAMPLE_REV}") { "" }
+      stub(GitCommitNotifier::Git).from_shell("git rev-list --reverse #{SAMPLE_REV} ^#{SAMPLE_REV_2}") { SAMPLE_REV }
+      mock(GitCommitNotifier::Git).from_shell("git rev-list --reverse ^#{SAMPLE_REV} ^#{SAMPLE_REV_2} #{SAMPLE_REV}") { "" }
       GitCommitNotifier::Git.new_commits("0000000000000000000000000000000000000000", SAMPLE_REV, "refs/heads/branch2", true).should == []
     end
   end


### PR DESCRIPTION
Again, spec for #136.  Probably a good idea to mock the function that returns the same
values in ruby 1.8 and 1.9, not the other one...
