### PR TITLE
fix typo for webhook when group_email_by_push: true

### DIFF
--- a/lib/git_commit_notifier/commit_hook.rb
+++ b/lib/git_commit_notifier/commit_hook.rb
@@ -199,7 +199,7 @@ module GitCommitNotifier
           emailer.send
 
           # WEBHOOK patch
-          unless config['webook'].nil?
+          unless config['webhook'].nil?
             webhook = Webhook.new(config,
               :committer => result[:commit_info][:author],
               :email => result[:commit_info][:email],


### PR DESCRIPTION
stupid typo that made it fails to send webhook when group_email_by_push: true
