### PR TITLE
Added Summary to Commit Mails

### DIFF
--- a/config/git-notifier-config.example.yml
+++ b/config/git-notifier-config.example.yml
@@ -10,6 +10,9 @@ lines_per_diff: 300
 # Show file list only when too many files
 too_many_files: 50
 
+# Show summary before changes
+show_summary: true
+
 # Whether to expand css inline. May be compatible with more mail readers
 # but consumes much more space and more cpu. Defaults to true
 # expand_css: true


### PR DESCRIPTION
If you have a commit mail with a lot of changes you have to scroll through the whole mail to see what files have been changed. To avoid this I added a little summary after the header which lists all changed files. You can simply click on a file in this list to jump down to the diff of this file. This new feature can be enabled or disabled in the config file.
