### PR TITLE
Bugfix for summary in combination with multiple commits

### DIFF
--- a/lib/git_commit_notifier/diff_to_html.rb
+++ b/lib/git_commit_notifier/diff_to_html.rb
@@ -545,9 +545,11 @@ module GitCommitNotifier
       title += "<dt>Message</dt><dd class='#{multi_line_message ? "multi-line" : ""}'>#{message_array_as_html(commit_info[:message])}</dd>\n"
       title += "</dl>"
 
+      @file_changes = []
+      text = ""
+
       html_diff = diff_for_revision(extract_diff_from_git_show_output(raw_diff))
       message_array = message_array_as_html(changed_files.split("\n"))
-      text = ""
 
       if show_summary? and @file_changes.respond_to?("each")
         title += "<ul>"


### PR DESCRIPTION
There was a small bug in the summary when multiple commits were pushed at the same time. The script didn't retested the list of files between the commits so that the list of the changed files from one commit was included in all following commits.
