### PR TITLE
Small patch to allow per-branch mailing lists

### DIFF
--- a/lib/git_commit_notifier/commit_hook.rb
+++ b/lib/git_commit_notifier/commit_hook.rb
@@ -100,8 +100,7 @@ module GitCommitNotifier
         slash_branch_name = "" if !config["show_master_branch_name"] && slash_branch_name == '/master'
 
         # Identify email recipients
-        recipient = config["#{branch_name}_mailinglist"] || config["mailinglis
-t"] || Git.mailing_list_address
+        recipient = config["#{branch_name}_mailinglist"] || config["mailinglist"] || Git.mailing_list_address
 
         # If no recipients specified, bail out gracefully. This is not an error, and might be intentional
         if recipient.nil? || recipient.length == 0


### PR DESCRIPTION
Basically this allows config lines like

mailinglist: usual_suspects@example.com
master_mailinglist: extra_guy@example.com, usual_suspects@example.com
test_mailinglist: just_me@example.com

so you can specify that commits emails go to the usual suspects, but commits on the
master branch go to extray_guy as well, and commits on the test branch go to
just_me.
