### PR TITLE
This patch lets you have a per-branch mailing list

### DIFF
--- a/lib/git_commit_notifier/commit_hook.rb
+++ b/lib/git_commit_notifier/commit_hook.rb
@@ -100,8 +100,7 @@ module GitCommitNotifier
         slash_branch_name = "" if !config["show_master_branch_name"] && slash_branch_name == '/master'
 
         # Identify email recipients
-        recipient = config["#{branch_name}_mailinglist"] || config["mailinglis
-t"] || Git.mailing_list_address
+        recipient = config["#{branch_name}_mailinglist"] || config["mailinglist"] || Git.mailing_list_address
 
         # If no recipients specified, bail out gracefully. This is not an error, and might be intentional
         if recipient.nil? || recipient.length == 0


### PR DESCRIPTION
So you can have:

```
mailinglist: usual_suspects@example.com
master_mailinglist: extra_guy@example.com, usual_suspects@example.com
test_mailinglist: just_me@example.com
```

To direct emails for commits on particular branches differently.
