### PR TITLE
Additional fix to issue #161: handle bare repository case

### DIFF
--- a/lib/git_commit_notifier/git.rb
+++ b/lib/git_commit_notifier/git.rb
@@ -171,7 +171,7 @@ class GitCommitNotifier::Git
         ''
       end
       return git_prefix  unless git_prefix.empty?
-      git_path = toplevel_dir.strip
+      git_path = toplevel_dir
       # In a bare repository, toplevel directory is empty.  Revert to git_dir instead.
       if git_path.empty?
         git_path = git_dir

--- a/spec/lib/git_commit_notifier/git_spec.rb
+++ b/spec/lib/git_commit_notifier/git_spec.rb
@@ -82,7 +82,7 @@ describe GitCommitNotifier::Git do
 
     it "should return folder name if no emailprefix and toplevel dir and directory not ended with .git" do
       mock(GitCommitNotifier::Git).from_shell("git config hooks.emailprefix") { " " }
-      stub(GitCommitNotifier::Git).toplevel_dir { " " }
+      stub(GitCommitNotifier::Git).toplevel_dir { "" }
       stub(GitCommitNotifier::Git).git_dir { "/home/someuser/repositories/myrepo.git" }
       GitCommitNotifier::Git.repo_name.should == "myrepo"
     end


### PR DESCRIPTION
In a bare repository, git rev-parse --show-toplevel is empty.

In a non-bare repository, git rev-parse --git-dir returns the .git dir.

While the initial fixed the non-bare case, it broke the bare repository case.  Now if we don't get a toplevel dir, attempt to use the git-dir.
