### PR TITLE
Support Gitlabhq 4.0 links

### DIFF
--- a/lib/git_commit_notifier/diff_to_html.rb
+++ b/lib/git_commit_notifier/diff_to_html.rb
@@ -197,7 +197,9 @@ module GitCommitNotifier
         elsif config["link_files"] == "gitlabhq" && config["gitlabhq"]
           if config["gitlabhq"]["version"] && config["gitlabhq"]["version"] < 1.2
             "<a href='#{config['gitlabhq']['path']}/#{Git.repo_name.gsub(".", "_")}/tree/#{@current_commit}/#{file_name}'>#{file_name}</a>"
-          else
+          elsif config["gitlabhq"]["version"] && config["gitlabhq"]["version"] >= 4.0
+			"<a href='#{config['gitlabhq']['path']}/#{Git.repo_name_with_parent.gsub(".", "_")}/commit/#{@current_commit}'>#{file_name}</a>"
+		  else
             "<a href='#{config['gitlabhq']['path']}/#{Git.repo_name.gsub(".", "_")}/#{@current_commit}/tree/#{file_name}'>#{file_name}</a>"
           end
         elsif config["link_files"] == "redmine" && config["redmine"]

--- a/lib/git_commit_notifier/git.rb
+++ b/lib/git_commit_notifier/git.rb
@@ -179,6 +179,28 @@ class GitCommitNotifier::Git
       File.expand_path(git_path).split("/").last.sub(/\.git$/, '')
     end
 
+	# Gets repository name.
+    # @note Tries to gets human readable repository name through `git config hooks.emailprefix` call.
+    #       If it's not specified then returns directory name with parent directory name (except '.git'
+	#       suffix if exists).
+    # @return [String] Human readable repository name.
+    def repo_name_with_parent
+      git_prefix = begin
+        from_shell("git config hooks.emailprefix").strip
+      rescue ArgumentError
+        ''
+      end
+      return git_prefix  unless git_prefix.empty?
+      git_path = toplevel_dir
+      # In a bare repository, toplevel directory is empty.  Revert to git_dir instead.
+      if git_path.empty?
+        git_path = git_dir
+      end
+      name_with_parent = File.expand_path(git_path).scan(/[a-zA-z0-9]+\/[a-zA-Z0-9]+.git$/).first;
+      return name_with_parent.sub(/\.git$/, '') unless name_with_parent.empty?
+      File.expand_path(git_path).split("/").last.sub(/\.git$/, '')
+    end
+
     # Gets mailing list address.
     # @note mailing list address retrieved through `git config hooks.mailinglist` call.
     # @return [String] Mailing list address if exists; otherwise nil.


### PR DESCRIPTION
Recent changes to the way Gitlabhq arranges repository directories broke the support for email links. This is an attempt to fix them. Please consider merging.
