### PR TITLE
More fine-grained options for ignore_whitespace (all, change, none).

### DIFF
--- a/config/git-notifier-config.example.yml
+++ b/config/git-notifier-config.example.yml
@@ -180,7 +180,10 @@ unique_commits_per_branch: false
 show_master_branch_name: false
 
 # ignore whitespace?
-ignore_whitespace: true
+#  all: ignore all whitespace (same as true)
+#  change: ignore changes in amount of whitespace
+#  none: do not ignore any whitespace (same as false)
+ignore_whitespace: all
 
 # adding parameters to send webhooks
 # webooks:

--- a/lib/git_commit_notifier/diff_to_html.rb
+++ b/lib/git_commit_notifier/diff_to_html.rb
@@ -90,9 +90,11 @@ module GitCommitNotifier
     end
 
     # Gets ignore_whitespace setting from {#config}.
-    # @return [Boolean] true if whitespaces should be ignored in diff; otherwise false.
-    def ignore_whitespaces?
-      config['ignore_whitespace'].nil? || config['ignore_whitespace']
+    # @return [String] How whitespaces should be treated in diffs (none, all, change)
+    def ignore_whitespace
+      return 'all' if config['ignore_whitespace'].nil?
+      return 'none' if !config['ignore_whitespace']
+      return (['all', 'change', 'none'].include?(config['ignore_whitespace']) ? config['ignore_whitespace'] : 'all')
     end
 
     # Adds separator between diff blocks to @diff_result.
@@ -515,7 +517,7 @@ module GitCommitNotifier
 
     def diff_for_commit(commit)
       @current_commit = commit
-      raw_diff = truncate_long_lines(Git.show(commit, :ignore_whitespaces => ignore_whitespaces?))
+      raw_diff = truncate_long_lines(Git.show(commit, :ignore_whitespace => ignore_whitespace))
       raise "git show output is empty" if raw_diff.empty?
 
       commit_info = extract_commit_info_from_git_show_output(raw_diff)

--- a/lib/git_commit_notifier/git.rb
+++ b/lib/git_commit_notifier/git.rb
@@ -30,11 +30,12 @@ class GitCommitNotifier::Git
     # @see from_shell
     # @param [String] rev Revision
     # @param [Hash] opts Options
-    # @option opts [Boolean] :ignore_whitespaces Ignore whitespaces or not
+    # @option opts [String] :ignore_whitespace How whitespaces should be treated
     def show(rev, opts = {})
       gitopt = " --date=rfc2822"
       gitopt += " --pretty=fuller"
-      gitopt += " -w" if opts[:ignore_whitespaces]
+      gitopt += " -w" if opts[:ignore_whitespace] == 'all'
+      gitopt += " -b" if opts[:ignore_whitespace] == 'change'
       from_shell("git show #{rev.strip}#{gitopt}")
     end
 

--- a/spec/lib/git_commit_notifier/commit_hook_spec.rb
+++ b/spec/lib/git_commit_notifier/commit_hook_spec.rb
@@ -79,7 +79,7 @@ describe GitCommitNotifier::CommitHook do
     mock(GitCommitNotifier::Git).repo_name { 'testproject' }
     mock(GitCommitNotifier::Git).changed_files('7e4f6b4', '4f13525') { [] }
     REVISIONS.each do |rev|
-      mock(GitCommitNotifier::Git).show(rev, :ignore_whitespaces => true) { IO.read(FIXTURES_PATH + "git_show_#{rev}") }
+      mock(GitCommitNotifier::Git).show(rev, :ignore_whitespace => 'all') { IO.read(FIXTURES_PATH + "git_show_#{rev}") }
       dont_allow(GitCommitNotifier::Git).describe(rev) { IO.read(FIXTURES_PATH + "git_describe_#{rev}") }
     end
   end

--- a/spec/lib/git_commit_notifier/diff_to_html_spec.rb
+++ b/spec/lib/git_commit_notifier/diff_to_html_spec.rb
@@ -106,7 +106,7 @@ describe GitCommitNotifier::DiffToHtml do
     mock(GitCommitNotifier::Git).rev_type(REVISIONS.last) { "commit" }
     mock(GitCommitNotifier::Git).new_commits(anything, anything, anything, anything) { REVISIONS.reverse }
     REVISIONS.each do |rev|
-      mock(GitCommitNotifier::Git).show(rev, :ignore_whitespaces => true) { IO.read(FIXTURES_PATH + 'git_show_' + rev) }
+      mock(GitCommitNotifier::Git).show(rev, :ignore_whitespace => 'all') { IO.read(FIXTURES_PATH + 'git_show_' + rev) }
       dont_allow(GitCommitNotifier::Git).describe(rev) { IO.read(FIXTURES_PATH + 'git_describe_' + rev) }
     end
 
@@ -161,7 +161,7 @@ describe GitCommitNotifier::DiffToHtml do
     mock(GitCommitNotifier::Git).rev_type(last_rev) { "commit" }
     mock(GitCommitNotifier::Git).new_commits(anything, anything, anything, anything) { [ 'ff037a73fc1094455e7bbf506171a3f3cf873ae6' ] }
     %w[ ff037a73fc1094455e7bbf506171a3f3cf873ae6 ].each do |rev|
-      mock(GitCommitNotifier::Git).show(rev, :ignore_whitespaces => true) { IO.read(FIXTURES_PATH + 'git_show_' + rev) }
+      mock(GitCommitNotifier::Git).show(rev, :ignore_whitespace => 'all') { IO.read(FIXTURES_PATH + 'git_show_' + rev) }
       dont_allow(GitCommitNotifier::Git).describe(rev) { IO.read(FIXTURES_PATH + 'git_describe_' + rev) }
     end
     diff = GitCommitNotifier::DiffToHtml.new

--- a/spec/lib/git_commit_notifier/git_spec.rb
+++ b/spec/lib/git_commit_notifier/git_spec.rb
@@ -17,18 +17,18 @@ describe GitCommitNotifier::Git do
     it "should get data from shell: git show without whitespaces" do
       expected = 'some data from git show'
       mock(GitCommitNotifier::Git).from_shell("git show #{SAMPLE_REV} --date=rfc2822 --pretty=fuller -w") { expected }
-      GitCommitNotifier::Git.show(SAMPLE_REV, :ignore_whitespaces => true).should == expected
+      GitCommitNotifier::Git.show(SAMPLE_REV, :ignore_whitespace => 'all').should == expected
     end
 
     it "should get data from shell: git show with whitespaces" do
       expected = 'some data from git show'
       mock(GitCommitNotifier::Git).from_shell("git show #{SAMPLE_REV} --date=rfc2822 --pretty=fuller") { expected }
-      GitCommitNotifier::Git.show(SAMPLE_REV, :ignore_whitespaces => false).should == expected
+      GitCommitNotifier::Git.show(SAMPLE_REV, :ignore_whitespace => 'none').should == expected
     end
 
     it "should strip given revision" do
       mock(GitCommitNotifier::Git).from_shell("git show #{SAMPLE_REV} --date=rfc2822 --pretty=fuller -w")
-      GitCommitNotifier::Git.show("#{SAMPLE_REV}\n", :ignore_whitespaces => true)
+      GitCommitNotifier::Git.show("#{SAMPLE_REV}\n", :ignore_whitespace => 'all')
     end
   end
 


### PR DESCRIPTION
`ignore_whitespace` now accepts one of the following options:
- <tt>all</tt>: ignore all whitespace (`git show -w`)
- <tt>change</tt>: ignore changes in amount whitespace (`git show -b`)
- <tt>none</tt>: whitespace is not ignore  (just plain `git show`)

(For backward compatibility <tt>true</tt> maps to <tt>all</tt> and <tt>false</tt> to <tt>none</tt>.)
