### PR TITLE
Set Reply-to to recipient address

### DIFF
--- a/config/git-notifier-config.example.yml
+++ b/config/git-notifier-config.example.yml
@@ -76,8 +76,15 @@ prefer_git_config_mailinglist: false
 
 # If reply_to_author is set to true, the Reply-To address is same as the author's
 # email address, if not it will be same as the from address.
+# Note that you cannot set both, this and reply_to_mailinglist true!
 # Defaults to false
 # reply_to_author: false
+
+# If reply_to_mailinglist is set to true, the Reply-To address is same as the recipient
+# email address, or if that is missing, the same as hooks.mailinglist. If not it will be
+# same as the from address. Note that you cannot set both, this and reply_to_author true!
+# Defaults to false
+# reply_to_mailinglist: false
 
 # stylesheet file (embedded template/styles.css by default)
 # stylesheet: /absolute/path/to/readable/stylesheet.css

--- a/lib/git_commit_notifier/commit_hook.rb
+++ b/lib/git_commit_notifier/commit_hook.rb
@@ -137,6 +137,15 @@ module GitCommitNotifier
           return
         end
 
+        reply_to_address = nil
+        if config["reply_to_author"]
+          reply_to_address ||= result[:commit_info][:email]
+        elsif config["reply_to_mailinglist"]
+          reply_to_address ||= recipient
+        else
+          reply_to_address ||= config["from"]
+        end
+
         # Debug information
         logger.debug('----')
         logger.debug("cwd: #{Dir.pwd}")
@@ -217,7 +226,7 @@ module GitCommitNotifier
             :recipient => config["send_mail_to_committer"] ? add_committer_to_recipient(recipient, result[:commit_info][:email]) : recipient,
             :from_address => config["from"] || result[:commit_info][:email],
             :from_alias => result[:commit_info][:author],
-            :reply_to_address => config["reply_to_author"] ? result[:commit_info][:email] : config["from"] || result[:commit_info][:email],
+            :reply_to_address => reply_to_address,
             :subject => subject,
             :commit_date => result[:commit_info][:date],
             :current_date => Time.new.rfc2822,
@@ -268,7 +277,7 @@ module GitCommitNotifier
               :recipient => config["send_mail_to_committer"] ? add_committer_to_recipient(recipient, result[:commit_info][:email]) : recipient,
               :from_address => config["from"] || result[:commit_info][:email],
               :from_alias => result[:commit_info][:author],
-              :reply_to_address => config["reply_to_author"] ? result[:commit_info][:email] : config["from"] || result[:commit_info][:email],
+              :reply_to_address => reply_to_address,
               :subject => subject,
               :commit_date => result[:commit_info][:date],
               :current_date => Time.new.rfc2822,


### PR DESCRIPTION
we introduce a new option: reply_to_mailinglist. This option is mutually
exclusive to reply_to_author. It gives us the ability to set the
Reply-To adddress to the either the recipient/mailinglist and fixes #187
