### PR TITLE
Turning on reply_to_author option cause undefined local variable or method `result'

### DIFF
--- a/lib/git_commit_notifier/emailer.rb
+++ b/lib/git_commit_notifier/emailer.rb
@@ -181,7 +181,7 @@ class GitCommitNotifier::Emailer
     to_tag = config['delivery_method'] == 'nntp' ? 'Newsgroups' : 'To'
     quoted_from_alias = !@from_alias.nil? ? quote_if_necessary("#{@from_alias}",'utf-8') : nil
     from = (@from_alias.nil? || @from_alias.empty?) ? @from_address : "#{quoted_from_alias} <#{@from_address}>"
-    reply_to = (@from_alias.nil? || @from_alias.empty? || config['reply_to_author'] || config['reply_to_mailinglist']) ? @reply_to_address : "#{quoted_from_alias} <#{@reply_to_address}>"
+    reply_to = (@from_alias.nil? || !config['reply_to_author']) ? @reply_to_address : "#{@from_alias} <#{@reply_to_address}>"
 
     plaintext = if config['add_plaintext'].nil? || config['add_plaintext']
       @text_message


### PR DESCRIPTION
Hi, Like it is described in subject, when I've turned on reply_to_author option, sending email fails. The reason is that result is not available before diff extraction. Please consider pulling up my fix.

Cheers, Arek
