### PR TITLE
Adds Bcc support to the Emailer

### DIFF
--- a/config/git-notifier-config.example.yml
+++ b/config/git-notifier-config.example.yml
@@ -22,6 +22,10 @@ show_summary: true
 # of generated emails. Defaults to true
 # add_plaintext: true
 
+# Put the recepients in the Bcc field. This only applies if the delivery_method
+# is not nntp. Defaults to false
+bcc_recepients: false
+
 # Subject: the subject may be set by specifying a template.
 #
 # Substitution into the template is available for the following

--- a/lib/git_commit_notifier/emailer.rb
+++ b/lib/git_commit_notifier/emailer.rb
@@ -221,6 +221,13 @@ class GitCommitNotifier::Emailer
     date = @offset_date     # Date notifier started, plus 1 second per commit processed
     date = Time.new.rfc2822 if date.nil?    # Fallback to current date if date is nil
 
+    # Check if the recepients are set to be sent via Bcc and set the To to the commit
+    # author
+    if config['bcc_recepients'] && config['delivery_method'] != 'nntp'
+      content << "To: #{from}"
+      to_tag = 'Bcc'
+    end
+
     content.concat [
         "#{to_tag}: #{quote_if_necessary(@recipient, 'utf-8')}",
         "Date: #{date}",


### PR DESCRIPTION
Adds the bcc_recepients option to the config file that allows
the recepients to be sent via Bcc if set and if the delivery_method
is not nntp. Defaults to false.