### PR TITLE
fix "this operation must be run in a work tree" error with latest version of git

### DIFF
--- a/config/git-notifier-config.example.yml
+++ b/config/git-notifier-config.example.yml
@@ -1,6 +1,10 @@
 # set to true if you want to ignore empty merge messages
 ignore_merge: false
 
+# If any commit in a push is a merge,
+# setting this to true will ignore all non-merge commits in that push.
+ignore_merge_dependencies: false
+
 # Optional parameter for the subject-line of the mail
 # emailprefix: GIT
 

--- a/lib/git_commit_notifier/diff_to_html.rb
+++ b/lib/git_commit_notifier/diff_to_html.rb
@@ -99,6 +99,11 @@ module GitCommitNotifier
       config['ignore_merge']
     end
 
+    # Gets ignore_merge_dependencies setting from {#config}.
+    def ignore_merge_dependencies?
+      config['ignore_merge_dependencies']
+    end
+
     # Gets show_summary setting from {#config}.
     def show_summary?
       config['show_summary']
@@ -882,6 +887,11 @@ module GitCommitNotifier
       # Remove merge commits if required
       if ignore_merge?
         @result.reject! { |commit| merge_commit?(commit[:commit_info]) }
+      end
+
+      # If any commit is a merge, ignore all non-merge commits (if requested)
+      if ignore_merge_dependencies? and @result.count { |commit| merge_commit?(commit[:commit_info]) } > 0
+        @result.select! { |commit| merge_commit?(commit[:commit_info]) }
       end
 
       # If a block was given, pass it the results, in turn

--- a/lib/git_commit_notifier/git.rb
+++ b/lib/git_commit_notifier/git.rb
@@ -119,7 +119,7 @@ class GitCommitNotifier::Git
     end
 
     def toplevel_dir
-      from_shell("git rev-parse --show-toplevel").strip
+      from_shell("git rev-parse --absolute-git-dir").strip
     end
 
     def rev_parse(param)

--- a/lib/git_commit_notifier/git.rb
+++ b/lib/git_commit_notifier/git.rb
@@ -115,11 +115,11 @@ class GitCommitNotifier::Git
     end
 
     def git_dir
-      from_shell("git rev-parse --git-dir").strip
+      @git_dir ||= from_shell("git rev-parse --git-dir").strip
     end
 
     def toplevel_dir
-      from_shell("git rev-parse --show-toplevel").strip
+      @toplevel_dir ||= from_shell("git rev-parse --show-toplevel").strip
     end
 
     def rev_parse(param)
@@ -215,18 +215,23 @@ class GitCommitNotifier::Git
     #       If it's not specified then returns directory name (except '.git' suffix if exists).
     # @return [String] Human readable repository name.
     def repo_name
+      return @repo_name if @repo_name
+
       git_prefix = begin
         from_shell("git config hooks.emailprefix").strip
       rescue ArgumentError
         ''
       end
-      return git_prefix  unless git_prefix.empty?
+      if not git_prefix.empty?
+        @repo_name = git_prefix
+        return git_prefix
+      end
       git_path = toplevel_dir
       # In a bare repository, toplevel directory is empty.  Revert to git_dir instead.
       if git_path.empty?
         git_path = git_dir
       end
-      File.expand_path(git_path).split("/").last.sub(/\.git$/, '')
+      @repo_name = File.expand_path(git_path).split("/").last.sub(/\.git$/, '')
     end
 
     # Gets repository name.


### PR DESCRIPTION
I used this fix to get the git notifications back working. Not completely sure if this is the "right" fix, but it works for me ;-)